### PR TITLE
28 common logic needs to be reworked for binarys

### DIFF
--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -8,7 +8,7 @@
     - openshift-client-linux.tar.gz
     - oc-mirror.tar.gz
     - openshift-install-linux.tar.gz
-  listen: "Download_oc"
+  listen: "Download_bin"
 
 - name: Extract oc tools
   ansible.builtin.unarchive:
@@ -22,7 +22,7 @@
     - openshift-client-linux.tar.gz
     - oc-mirror.tar.gz
     - openshift-install-linux.tar.gz
-  listen: "Download_oc"
+  listen: "Download_bin"
 
 - name: Remove oc tools tar
   ansible.builtin.file:
@@ -30,14 +30,14 @@
     state: absent
   with_fileglob:
     - "{{ common_openshift_download_dir }}/*tar.gz"
-  listen: "Download_oc"
+  listen: "Download_bin"
 
 - name: Download trident tar
   ansible.builtin.get_url:
     url: "https://github.com/NetApp/trident/releases/download/{{ common_trident_version }}/trident-installer-{{ common_trident_version  | replace('v', '') }}.tar.gz"
     dest: "{{ common_openshift_download_dir }}"
     mode: '0755'
-  listen: "Download_tridantctl"
+  listen: "Download_bin"
 
 - name: Extract trident binary
   ansible.builtin.unarchive:
@@ -46,7 +46,7 @@
     include:
       - trident-installer/tridentctl
     dest: "{{ common_openshift_client_bin }}"
-  listen: "Download_tridantctl"
+  listen: "Download_bin"
 
 - name: Move tridentctl to proper location
   ansible.builtin.copy:
@@ -54,27 +54,27 @@
     src: "{{ common_openshift_client_bin }}/trident-installer/tridentctl"
     dest: "{{ common_openshift_client_bin }}/tridentctl"
     mode: '0755'
-  listen: "Download_tridantctl"
+  listen: "Download_bin"
 
 - name: Remove trident-installer/tridentctl
   ansible.builtin.file:
     path: "{{ common_openshift_client_bin }}/trident-installer"
     state: absent
-  listen: "Download_tridantctl"
+  listen: "Download_bin"
 
 - name: Download butane binary
   ansible.builtin.get_url:
     url: "{{ common_openshift_download_base_url }}/butane/latest/butane"
     dest: "{{ common_openshift_client_bin }}"
     mode: '0755'
-  listen: Download_butane
+  listen: "Download_bin"
 
 - name: Download helm binary
   ansible.builtin.get_url:
     url: "{{ common_openshift_download_base_url }}/helm/latest/helm-linux-amd64"
     dest: "{{ common_openshift_client_bin }}/helm"
     mode: '0755'
-  listen: Download_helm
+  listen: "Download_bin"
 
 - name: Pull registry image
   containers.podman.podman_image:

--- a/roles/common/handlers/main.yml
+++ b/roles/common/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Download_oc_tools
+- name: Download oc tools
   ansible.builtin.get_url:
     url: "{{ common_openshift_download_base_url }}/ocp/{{ common_openshift_release }}/{{ item }}"
     dest: "{{ common_openshift_download_dir }}"
@@ -10,7 +10,7 @@
     - openshift-install-linux.tar.gz
   listen: "Download_oc"
 
-- name: Extract_oc_tools
+- name: Extract oc tools
   ansible.builtin.unarchive:
     src: "{{ common_openshift_download_dir }}/{{ item }}"
     remote_src: true
@@ -24,7 +24,7 @@
     - openshift-install-linux.tar.gz
   listen: "Download_oc"
 
-- name: Remove_oc_tools_tar
+- name: Remove oc tools tar
   ansible.builtin.file:
     path: "{{ item }}"
     state: absent
@@ -32,62 +32,62 @@
     - "{{ common_openshift_download_dir }}/*tar.gz"
   listen: "Download_oc"
 
-- name: Download_trident
+- name: Download trident tar
   ansible.builtin.get_url:
     url: "https://github.com/NetApp/trident/releases/download/{{ common_trident_version }}/trident-installer-{{ common_trident_version  | replace('v', '') }}.tar.gz"
     dest: "{{ common_openshift_download_dir }}"
     mode: '0755'
-  listen: "Download_tridant"
+  listen: "Download_tridantctl"
 
-- name: Extract_trident_binary
+- name: Extract trident binary
   ansible.builtin.unarchive:
     src: "{{ common_openshift_download_dir }}/trident-installer-{{ common_trident_version | replace('v', '') }}.tar.gz"
     remote_src: true
     include:
       - trident-installer/tridentctl
     dest: "{{ common_openshift_client_bin }}"
-  listen: "Download_tridant"
+  listen: "Download_tridantctl"
 
-- name: Move_tridentctl_to_proper_location
+- name: Move tridentctl to proper location
   ansible.builtin.copy:
     remote_src: true
     src: "{{ common_openshift_client_bin }}/trident-installer/tridentctl"
     dest: "{{ common_openshift_client_bin }}/tridentctl"
     mode: '0755'
-  listen: "Download_tridant"
+  listen: "Download_tridantctl"
 
-- name: Remove_trident-installer/tridentctl
+- name: Remove trident-installer/tridentctl
   ansible.builtin.file:
     path: "{{ common_openshift_client_bin }}/trident-installer"
     state: absent
-  listen: "Download_tridant"
+  listen: "Download_tridantctl"
 
-- name: Download_butane
+- name: Download butane binary
   ansible.builtin.get_url:
     url: "{{ common_openshift_download_base_url }}/butane/latest/butane"
     dest: "{{ common_openshift_client_bin }}"
     mode: '0755'
-  listen: download_butane
+  listen: Download_butane
 
-- name: Download_helm
+- name: Download helm binary
   ansible.builtin.get_url:
     url: "{{ common_openshift_download_base_url }}/helm/latest/helm-linux-amd64"
     dest: "{{ common_openshift_client_bin }}/helm"
     mode: '0755'
-  listen: download_helm
+  listen: Download_helm
 
-- name: Pull_registry_image
+- name: Pull registry image
   containers.podman.podman_image:
     name: docker.io/library/registry
   listen: Registry_image
 
-- name: Save_registry_image
+- name: Save registry image
   containers.podman.podman_save:
     image: docker.io/library/registry
     dest: "{{ common_openshift_oc_mirror_dir }}/registry.tar"
   listen: Registry_image
    
-- name: Download_RHCOS_image
+- name: Download RHCOS image
   get_url:
     url: "{{ rhcos_image_url }}"
     dest: "{{ common_openshift_download_dir }}/"
@@ -107,3 +107,14 @@
   with_fileglob:
     - "{{ common_openshift_download_dir }}/*iso"
   listen: rhcos_image
+
+- name: Move binaries to destination directory
+  ansible.builtin.copy:
+    src: "{{ item }}"
+    dest: /usr/bin/
+    mode: '0755'
+    remote_src: yes
+  become: true
+  with_fileglob:
+    - "{{ common_openshift_client_bin }}/*"
+  listen: Move_binaries

--- a/roles/common/tasks/gather-content.yml
+++ b/roles/common/tasks/gather-content.yml
@@ -96,6 +96,3 @@
 - name: Force all notified handlers to run at this point, not waiting for normal sync points
   ansible.builtin.meta: flush_handlers
 
-- name: purpose fail playbook
-  ansible.builtin.fail:
-    msg: stop

--- a/roles/common/tasks/gather-content.yml
+++ b/roles/common/tasks/gather-content.yml
@@ -18,17 +18,15 @@
   changed_when: 
     - 'install_check.rc != 0'
     - "'{{ common_openshift_release}}' not in install_check.stdout"
-  notify:
-    - Download_oc
+  notify: Download_oc
 
 - name: Check if tridentctl binary is present
   ansible.builtin.stat:
     path: /usr/bin/tridentctl
-  register: trident
+  register: tridentctl
   failed_when: false
-  changed_when: "not trident.stat.exists"
-  notify:
-    - Download_trident
+  changed_when: "not tridentctl.stat.exists"
+  notify: "Download_tridantctl"
 
 - name: Check if butane binary is present
   ansible.builtin.stat:
@@ -36,8 +34,7 @@
   failed_when: false
   register: butane
   changed_when: "not butane.stat.exists"
-  notify:
-    - Download_butane
+  notify: "Download_butane"
 
 - name: Check if helm binary is present
   ansible.builtin.stat:
@@ -45,8 +42,21 @@
   failed_when: false
   register: helm
   changed_when: 'not helm.stat.exists'
+  notify: "Download_helm"
+
+- name: Check for binaries in /usr/bin
+  ansible.builtin.stat: 
+    path: "/usr/bin/{{ item }}"
+  register: bin
+  failed_when: false
+  changed_when: "not bin.stat.exists"
   notify:
-    - Download_helm
+    - Move_binaries
+  with_items:
+    - oc
+    - helm
+    - butane
+    - tridentctl
 
 - name: Check for saved registry
   ansible.builtin.stat:
@@ -63,8 +73,16 @@
   register: cache_dir
   failed_when: false
   changed_when: 'not cache_dir.stat.exists'
-  notify:
-    - rhcos_image
+
+- name: Force all notified handlers to run at this point, not waiting for normal sync points
+  ansible.builtin.meta: flush_handlers
+  notify: Move_binaries
+
+- name: Download required ansible collections
+  community.general.ansible_galaxy_install:
+    type: collection
+    dest: "{{ common_openshift_download_dir }}/collections"
+    requirements_file: "{{ playbook_dir }}/../collections/requirements.yml"
 
 - name: Find pre-staged RHCOS image if .cache directory exists
   ansible.builtin.find:
@@ -89,11 +107,9 @@
       rhcos_image_url: "{{ rhcos_image_info.stdout | from_json | json_query('architectures.x86_64.artifacts.metal.formats.iso.disk.location') }}"
   when: 'not cache_dir.stat.exists or rhcos.matched == 0'
 
-- name: Download required ansible collections
-  community.general.ansible_galaxy_install:
-    type: collection
-    dest: "{{ common_openshift_download_dir }}/collections"
-    requirements_file: "{{ playbook_dir }}/../collections/requirements.yml"
-
 - name: Force all notified handlers to run at this point, not waiting for normal sync points
   ansible.builtin.meta: flush_handlers
+
+- name: purpose fail playbook
+  ansible.builtin.fail:
+    msg: stop

--- a/roles/common/tasks/gather-content.yml
+++ b/roles/common/tasks/gather-content.yml
@@ -10,52 +10,38 @@
     - "{{ common_openshift_download_dir }}"
     - "{{ common_openshift_download_dir }}/collections"
 
-- name: Check if openshift-install is available
-  ansible.builtin.shell: "openshift-install version"
-  register: install_check
-  failed_when: false
-  ignore_errors: true
-  changed_when: 
-    - 'install_check.rc != 0'
-    - "'{{ common_openshift_release}}' not in install_check.stdout"
-  notify: Download_oc
-
-- name: Check if tridentctl binary is present
+- name: Check for binaries in {{ common_openshift_client_bin }}
   ansible.builtin.stat:
-    path: /usr/bin/tridentctl
-  register: tridentctl
+    path: "{{ common_openshift_client_bin }}/{{ item }}"
+  register: move_bin
   failed_when: false
-  changed_when: "not tridentctl.stat.exists"
-  notify: "Download_tridantctl"
-
-- name: Check if butane binary is present
-  ansible.builtin.stat:
-    path: /usr/bin/butane
-  failed_when: false
-  register: butane
-  changed_when: "not butane.stat.exists"
-  notify: "Download_butane"
-
-- name: Check if helm binary is present
-  ansible.builtin.stat:
-    path: /usr/bin/helm
-  failed_when: false
-  register: helm
-  changed_when: 'not helm.stat.exists'
-  notify: "Download_helm"
+  changed_when: "not move_bin.stat.exists"
+  notify:
+    - Download_bin
+  with_items:
+    - butane
+    - helm
+    - kubectl
+    - oc
+    - oc-mirror
+    - openshift-install
+    - tridentctl
 
 - name: Check for binaries in /usr/bin
-  ansible.builtin.stat: 
+  ansible.builtin.stat:
     path: "/usr/bin/{{ item }}"
-  register: bin
+  register: download_bin
   failed_when: false
-  changed_when: "not bin.stat.exists"
+  changed_when: "not download_bin.stat.exists"
   notify:
     - Move_binaries
   with_items:
-    - oc
-    - helm
     - butane
+    - helm
+    - kubectl
+    - oc
+    - oc-mirror
+    - openshift-install
     - tridentctl
 
 - name: Check for saved registry


### PR DESCRIPTION
went with an "all or nothing" approach for now, it will:

1.  Check if binaries are in content_dir, if not (or any are missing), will download them all,
2. Check if binaries are in path (/usr/bin), if not ((or any are missing), will copy them all.

Had to go with this flow because the way hander cannot dynamically trigger notify/listeners. and handlers will run in the order they are triggered.

