### PR TITLE
Make Day1 helm automation more idempotent

### DIFF
--- a/roles/day1_automation/tasks/main.yml
+++ b/roles/day1_automation/tasks/main.yml
@@ -15,7 +15,7 @@
 
 - name: Generate day1 values file
   ansible.builtin.template:
-    src: "day1-values.yaml.j2" 
+    src: "day1-values.yaml.j2"
     dest: "{{ helm_values_filepath }}"
     mode: '0644'
     owner: "{{ ansible_user_id }}"

--- a/roles/day1_automation/tasks/main.yml
+++ b/roles/day1_automation/tasks/main.yml
@@ -15,17 +15,28 @@
 
 - name: Generate day1 values file
   ansible.builtin.template:
-    src: "day1-values.yaml.j2"
+    src: "day1-values.yaml.j2" 
     dest: "{{ helm_values_filepath }}"
     mode: '0644'
     owner: "{{ ansible_user_id }}"
     group: wheel
   become: true
 
-- name: run helm install command
+- name: Check for existing helm release
+  ansible.builtin.command:
+    cmd: "helm list | grep {{ helm_day1_release_name }} | wc -l"
+  register: helm_release_exists
+
+- name: Run a fresh helm install
   ansible.builtin.command: 
     cmd: "helm install {{ helm_day1_release_name }} {{ helm_options }} ."
   args:
     chdir: "{{ playbook_dir }}/../helm/openshift-gitops"
-  when: auto_run_helm | bool
+  when: auto_run_helm | bool and helm_release_exists.stdout == "0"
 
+- name: Run a helm upgrade on existing helm release
+  ansible.builtin.command: 
+    cmd: "helm upgrade {{ helm_day1_release_name }} ."
+  args:
+    chdir: "{{ playbook_dir }}/../helm/openshift-gitops"
+  when: auto_run_helm | bool and helm_release_exists.stdout != "0"

--- a/roles/day1_automation/tasks/main.yml
+++ b/roles/day1_automation/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Check for existing helm release
   ansible.builtin.command:
-    cmd: "helm list | grep {{ helm_day1_release_name }} | wc -l"
+    cmd: "helm list 2>/dev/null | grep {{ helm_day1_release_name }} | wc -l"
   register: helm_release_exists
 
 - name: Run a fresh helm install

--- a/roles/day1_automation/tasks/main.yml
+++ b/roles/day1_automation/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Check for existing helm release
   ansible.builtin.command:
-    cmd: "helm list 2>/dev/null | grep {{ helm_day1_release_name }} | wc -l"
+    cmd: "helm list 2>/dev/null"
   register: helm_release_exists
 
 - name: Run a fresh helm install
@@ -32,11 +32,11 @@
     cmd: "helm install {{ helm_day1_release_name }} {{ helm_options }} ."
   args:
     chdir: "{{ playbook_dir }}/../helm/openshift-gitops"
-  when: auto_run_helm | bool and helm_release_exists.stdout == "0"
+  when: auto_run_helm | bool and helm_day1_release_name not in helm_release_exists.stdout
 
 - name: Run a helm upgrade on existing helm release
   ansible.builtin.command: 
     cmd: "helm upgrade {{ helm_day1_release_name }} ."
   args:
     chdir: "{{ playbook_dir }}/../helm/openshift-gitops"
-  when: auto_run_helm | bool and helm_release_exists.stdout != "0"
+  when: auto_run_helm | bool and helm_day1_release_name in helm_release_exists.stdout

--- a/roles/day1_automation/tasks/main.yml
+++ b/roles/day1_automation/tasks/main.yml
@@ -24,7 +24,7 @@
 
 - name: Check for existing helm release
   ansible.builtin.command:
-    cmd: "helm list 2>/dev/null"
+    cmd: "helm list"
   register: helm_release_exists
 
 - name: Run a fresh helm install

--- a/roles/day1_automation/tasks/main.yml
+++ b/roles/day1_automation/tasks/main.yml
@@ -26,6 +26,11 @@
   ansible.builtin.command:
     cmd: "helm list"
   register: helm_release_exists
+  ignore_errors: yes
+
+- name: Display any existing helm releases
+  ansible.builtin.debug:
+    msg: "{{ helm_release_exists.stdout }}"
 
 - name: Run a fresh helm install
   ansible.builtin.command: 


### PR DESCRIPTION
checks for release of the same name. if exists it runs helm upgrade instead of helm install