### PR TITLE
Oc mirrorv2 fix

### DIFF
--- a/roles/common/defaults/main.yml
+++ b/roles/common/defaults/main.yml
@@ -11,6 +11,8 @@ common_trident_version: v24.06.0
 common_fips_enabled: true
 common_oc_mirror_v2: true
 
+
+
 ## OpenShift Connected Install Variables
 common_openshift_interface: eno1
 common_cluster_domain: example.com
@@ -19,6 +21,7 @@ commond_connected_cluster: true
 
 ## Openshift Disconnected Install Variables
 common_openshift_release: 4.14.16
+common_oc_mirror_release: 4.17.8
 common_previous_openshift_release: 4.14.16
 common_registry_volume: /pods/registry #### NEED TO RE-EVALUATE. FOR SOME REASON AGENT INSTALL USES THIS
 common_ip_space: 192.168.69

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -46,7 +46,6 @@
     mode: '0644'
   with_items:
     - openshift-client-linux.tar.gz
-    - oc-mirror.rhel9.tar.gz
     - openshift-install-linux.tar.gz
     - openshift-install-rhel9-amd64.tar.gz
   when: download_bin is changed

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -51,6 +51,16 @@
     - openshift-install-rhel9-amd64.tar.gz
   when: download_bin is changed
 
+
+- name: Download latest oc-mirror
+  ansible.builtin.get_url:
+    url: "{{ common_openshift_download_base_url }}/ocp/{{ common_oc_mirror_release }}/{{ item }}"
+    dest: "{{ common_openshift_download_dir }}"
+    mode: '0644'
+  with_items:
+    - oc-mirror.rhel9.tar.gz
+  when: download_bin is changed
+
 - name: Extract oc tools
   ansible.builtin.unarchive:
     src: "{{ common_openshift_download_dir }}/{{ item }}"


### PR DESCRIPTION
f you change your import_collection role in the config repo to point to that branch, then run the following you should be able to test a new pull.

```
rm /pods/content/bin/oc-mirror
sudo rm -rf /usr/bin/oc-mirror
rm -rf /pods/content/images
```
Then ./gather_content.yml and once that's done, move your /pods/content directory to anywhere else by doing something like 

```
sudo mkdir -p /opt/syscon
sudo cp -r /pods/content /opt/syscon/
sudo chown -R user:user /opt/syscon
```
Then edit your group_vars/all/cluster-deployment.yaml to also change it from /pods/content to /opt/syscon/content...
Then run ./deploy_cluster and everything should run successfully.